### PR TITLE
SFR-535 Format date response to ISO 8601 standard

### DIFF
--- a/api/prints/search.py
+++ b/api/prints/search.py
@@ -1,6 +1,4 @@
-from flask import (
-    Blueprint, request, session, url_for, redirect, current_app, jsonify
-)
+from flask import Blueprint, request, jsonify, make_response
 from sqlalchemy.orm.exc import NoResultFound
 
 from api.db import db, QueryManager
@@ -15,7 +13,11 @@ def fullTextQuery():
     queryText = request.args.get('query', '')
     sourceReturn = request.args.get('source', False)
     page, perPage = MultiResponse.parsePaging(request.args)
-    matchingDocs = elastic.query_fulltext(queryText, page=page, perPage=perPage)
+    matchingDocs = elastic.query_fulltext(
+        queryText,
+        page=page,
+        perPage=perPage
+    )
     textResponse = MultiResponse(
         'text',
         matchingDocs.hits.total,
@@ -29,7 +31,7 @@ def fullTextQuery():
         if entry.meta.index == 'cce':
             dbEntry = qManager.registrationQuery(entry.uuid)
             textResponse.addResult(MultiResponse.parseEntry(
-                dbEntry, 
+                dbEntry,
                 xml=sourceReturn
             ))
         else:
@@ -46,8 +48,8 @@ def fullTextQuery():
                     source=sourceReturn
                 ))
 
-    textResponse.createDataBlock()    
-    return jsonify(textResponse.createResponse(200))
+    textResponse.createDataBlock()
+    return make_response(jsonify(textResponse.createResponse(200)), 200)
 
 
 @search.route('/registration/<regnum>', methods=['GET'])
@@ -72,7 +74,7 @@ def regQuery(regnum):
         ))
 
     regResponse.createDataBlock()
-    return jsonify(regResponse.createResponse(200))
+    return make_response(jsonify(regResponse.createResponse(200)), 200)
 
 
 @search.route('/renewal/<rennum>', methods=['GET'])
@@ -93,11 +95,11 @@ def renQuery(rennum):
         dbRenewal = qManager.renewalQuery(entry.uuid)
         renResponse.extendResults(parseRetRenewal(
             dbRenewal,
-            source=sourceReturn    
+            source=sourceReturn
         ))
 
     renResponse.createDataBlock()
-    return jsonify(renResponse.createResponse(200))
+    return make_response(jsonify(renResponse.createResponse(200)), 200)
 
 
 def parseRetRenewal(dbRenewal):

--- a/api/prints/uuid.py
+++ b/api/prints/uuid.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, make_response
 from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -30,7 +30,10 @@ def regQuery(uuid):
     except DataError:
         status = 500
         err = LookupError('Malformed UUID {} received'.format(uuid))
-    return jsonify(regRecord.createResponse(status, err=err))
+    return make_response(
+        jsonify(regRecord.createResponse(status, err=err)),
+        status
+    )
 
 
 @uuid.route('/renewal/<uuid>', methods=['GET'])
@@ -51,7 +54,10 @@ def renQuery(uuid):
     except DataError:
         status = 500
         err = LookupError('Malformed UUID {} received'.format(uuid))
-    return jsonify(renRecord.createResponse(status, err=err))
+    return make_response(
+        jsonify(renRecord.createResponse(status, err=err)),
+        status
+    )
 
 
 def parseRetRenewal(dbRenewal):


### PR DESCRIPTION
This includes a fix to standardize output of dates to ISO 8601, replacing the current output of their display as entered in the copyright volumes.

This also includes several code formatting fixes and updates to the `search` and `uuid` endpoints to ensure that the proper status code is returned with non-200 responses.

The core of this update is in the `api/response.py` file starting on line 86 where the `formatDate` method has been added. This takes a `datetime` object from the database and formats it for display. 