### PR TITLE
SFR-539 Add new fields to source block

### DIFF
--- a/api/prints/swagger/swag.py
+++ b/api/prints/swagger/swag.py
@@ -310,22 +310,22 @@ class SwaggerDoc():
                     }
                 },
                 'Registration': {
-                    'type': 'object', 
+                    'type': 'object',
                     'properties': {
                         'title': {
                             'type': 'string'
                         },
                         'copies': {
                             'type': 'string'
-                        }, 
+                        },
                         'copy_date': {
                             'type': 'string'
-                        }, 
+                        },
                         'description': {
                             'type': 'string'
                         },
                         'authors': {
-                            'type': 'array', 
+                            'type': 'array',
                             'items': {
                                 '$ref': '#/definitions/Agent'
                             }
@@ -335,14 +335,14 @@ class SwaggerDoc():
                             'items': {
                                 '$ref': '#/definitions/Agent'
                             }
-                        }, 
+                        },
                         'registrations': {
                             'type': 'array',
                             'items': {
                                 '$ref': '#/definitions/RegRegistration'
                             }
-                        }, 
-                        'renewals':{
+                        },
+                        'renewals': {
                             'type': 'array',
                             'items': {
                                 '$ref': '#/definitions/Renewal'
@@ -353,35 +353,44 @@ class SwaggerDoc():
                             'properties': {
                                 'page': {
                                     'type': 'integer'
-                                }, 
+                                },
                                 'page_position': {
                                     'type': 'integer'
-                                }, 
+                                },
                                 'part': {
                                     'type': 'string'
-                                }, 
+                                },
+                                'group': {
+                                    'type': 'integer'
+                                },
                                 'series': {
                                     'type': 'string'
-                                }, 
+                                },
+                                'volume': {
+                                    'type': 'integer'
+                                },
+                                'matter': {
+                                    'type': 'string'
+                                },
                                 'url': {
                                     'type': 'string'
-                                }, 
+                                },
                                 'year': {
                                     'type': 'integer'
                                 }
                             }
                         }
                     }
-                }, 
+                },
                 'Agent': {
                     'type': 'string'
-                }, 
+                },
                 'RegRegistration': {
-                    'type': 'object', 
+                    'type': 'object',
                     'properties': {
                         'number': {
                             'type': 'string'
-                        }, 
+                        },
                         'date': {
                             'type': 'string'
                         }

--- a/api/response.py
+++ b/api/response.py
@@ -38,14 +38,27 @@ class Response():
             'authors': [a.name for a in dbEntry.authors],
             'publishers': [p.name for p in dbEntry.publishers],
             'source': {
-                'url': dbEntry.volume.source,
-                'series': dbEntry.volume.series,
-                'year': dbEntry.volume.year,
-                'part': dbEntry.volume.part,
                 'page': dbEntry.page,
-                'page_position': dbEntry.page_position
+                'page_position': dbEntry.page_position,
+                'part': dbEntry.volume.part,
+                'group': dbEntry.volume.group,
+                'series': dbEntry.volume.series,
+                'volume': dbEntry.volume.volume,
+                'matter': dbEntry.volume.material,
+                'url': dbEntry.volume.source,
+                'year': dbEntry.volume.year
             }
         }
+
+        if '3' in response['source']['series']:
+            startNum = dbEntry.volume.start_number
+            endNum = dbEntry.volume.end_number
+            if startNum == endNum:
+                outNum = startNum
+            else:
+                outNum = '{}-{}'.format(startNum, endNum)
+            response['source']['number'] = outNum
+
         response['renewals'] = [
             cls.parseRenewal(ren, source=xml)
             for reg in dbEntry.registrations


### PR DESCRIPTION
To help researchers identify the source for copyright entries the following fields (already stored in the database) are added to the API response:

- volume number
- group
- matter
- number (for 3rd series entries only)

The API checks to see if `3` appears in the `series` field and if so adds the `number` field.

This also adds these fields to the object definition in the Swagger documentation.