### PR TITLE
SFR-537 Add LCCN endpoint to CCE API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The search endpoints return many or no object depending on what search terms are
 The individual endpoints are:
 
 - `/search/fulltext?query=<query string>`: A full text query
+- `/search/lccn/<lccn>`: A query for a Library of Congress Control Number (LCCN)
 - `/search/registration/<regnum>`: A search for a specific registration number
 - `/search/renewal/<rennum>`: A search for a specific renewal number
 

--- a/api/elastic.py
+++ b/api/elastic.py
@@ -26,15 +26,21 @@ class Elastic():
     
     def query_fulltext(self, queryText, page=0, perPage=10):
         startPos, endPos = Elastic.getFromSize(page, perPage)
-        print(startPos, endPos)
         search = self.create_search('cce,ccr')
         renewalSearch = search.query('query_string', query=queryText)[startPos:endPos]
         return renewalSearch.execute()
-    
+
+    def query_lccn(self, lccn, page=0, perPage=10):
+        startPos, endPos = Elastic.getFromSize(page, perPage)
+        search = self.create_search('cce')
+        renewalSearch = search.query('term', lccns=lccn)[startPos:endPos]
+        return renewalSearch.execute()
+
     @staticmethod
     def getFromSize(page, perPage):
         startPos = page * perPage
         endPos = startPos + perPage
         return startPos, endPos
+
 
 elastic = Elastic()

--- a/api/prints/swagger/swag.py
+++ b/api/prints/swagger/swag.py
@@ -15,7 +15,7 @@ class SwaggerDoc():
                 'email': 'michaelbenowitz@nypl.org',
                 'url': 'www.nypl.org',
                 },
-                'version': 'v0.1'
+                'version': 'v0.2.3'
             },
             'basePath': '/',  # base bash for blueprint registration
             'schemes': [
@@ -139,6 +139,51 @@ class SwaggerDoc():
                                 'required': False,
                                 'default': 0
                             },{
+                                'name': 'per_page',
+                                'in': 'query',
+                                'type': 'number',
+                                'required': False,
+                                'default': 10
+                            }
+                        ],
+                        'responses': {
+                            200: {
+                                'description': 'A list of copyright registrations and renewals',
+                                'schema': {
+                                    '$ref': '#/definitions/MultiResponse'
+                                }
+                            }
+                        }
+                    }
+                },
+                '/search/lccn/{lccn}': {
+                    'get': {
+                        'tags': ['Search'],
+                        'summary': 'Returns a set of registration and renewal objects',
+                        'description': 'Accepts a Library of Congress Control Number (LCCN) and returns all matching records',
+                        'parameters': [
+                            {
+                                'name': 'lccn',
+                                'in': 'path',
+                                'required': True,
+                                'schema': {
+                                    'type': 'string'
+                                },
+                                'description': 'Library of Congress Control Number (LCCN)'
+                            },{
+                                'name': 'source',
+                                'in': 'query',
+                                'type': 'boolean',
+                                'required': False,
+                                'default': False,
+                                'description': 'Return source XML/CSV data'
+                            },{
+                                'name': 'page',
+                                'in': 'query',
+                                'type': 'number',
+                                'required': False,
+                                'default': 0
+                            }, {
                                 'name': 'per_page',
                                 'in': 'query',
                                 'type': 'number',

--- a/api/response.py
+++ b/api/response.py
@@ -47,7 +47,8 @@ class Response():
                 'matter': dbEntry.volume.material,
                 'url': dbEntry.volume.source,
                 'year': dbEntry.volume.year
-            }
+            },
+            'lccns': [l.lccn for l in dbEntry.lccns]
         }
 
         if '3' in response['source']['series']:


### PR DESCRIPTION
This adds a LCCN search endpoint to the API for this project and includes any LCCNs that are attached to CCE records in the API responses. These values are queried in the ElasticSearch index and fetched from the database along with the rest of the data when the response fields are gathered.